### PR TITLE
ci(git-hooks): adicionando arquivo de mensagem do husky

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+yarn commitlint --edit 


### PR DESCRIPTION
Mensagem para o commitlint dar erro de mensagem de commit fora do padrão.